### PR TITLE
Fix StopAction not fully complated..

### DIFF
--- a/Dzidek.Net.AutoUpgrade.Upgrader/UpgraderService.cs
+++ b/Dzidek.Net.AutoUpgrade.Upgrader/UpgraderService.cs
@@ -75,7 +75,7 @@ public sealed class UpgraderService : IHostedService
             Directory.CreateDirectory(newVersionPath);
         }
 
-        Repeat(StopAction);
+        StopAction;
         
         UnzipAndCopyFiles(newVersionPath, binPath, serviceOldVersionsPath);
 
@@ -89,8 +89,8 @@ public sealed class UpgraderService : IHostedService
 
 	private void Repeat(Action<TimeSpan> action)
 	{
-		TimeSpan time = TimeSpan.FromSeconds(10);
-		int i = 4;
+		TimeSpan time = TimeSpan.FromSeconds(5);
+		int i = 5;
 		while (i >= 0)
 		{
 			action(time);
@@ -109,7 +109,7 @@ public sealed class UpgraderService : IHostedService
         }
     }
 
-	private void StopAction(TimeSpan wait)
+	private void StopAction(TimeSpan wait = 10)
 	{
 		string serviceName = GetServiceName();
 

--- a/Dzidek.Net.AutoUpgrade.Upgrader/UpgraderService.cs
+++ b/Dzidek.Net.AutoUpgrade.Upgrader/UpgraderService.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.Diagnostics;
+using System.IO.Compression;
 using System.Management;
 using System.ServiceProcess;
 using Dzidek.Net.AutoUpgrade.Common;
@@ -23,7 +24,8 @@ public sealed class UpgraderService : IHostedService
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        string binPath = _configuration.ServicePath;
+       string binPath = _configuration.ServicePath;
+        
         string newVersionPath = Path.Combine(binPath, "NewVersion");
         if (!IsProperConfiguration(binPath))
         {
@@ -85,17 +87,19 @@ public sealed class UpgraderService : IHostedService
         return ServiceName.GetServiceName(_configuration.ServiceName, _configuration.ServiceNameSuffix);
     }
 
-    private void StopAction(TimeSpan wait)
-    {
-        ServiceController appDriver = new ServiceController(GetServiceName());
-        if (appDriver.Status == ServiceControllerStatus.Running)
-        {
-            appDriver.Stop();
-            appDriver.WaitForStatus(ServiceControllerStatus.Stopped, wait);
-        }
-    }
+	private void Repeat(Action<TimeSpan> action)
+	{
+		TimeSpan time = TimeSpan.FromSeconds(10);
+		int i = 4;
+		while (i >= 0)
+		{
+			action(time);
+			time *= 2;
+			i--;
+		}
+	}
 
-    private void StartAction(TimeSpan wait)
+	private void StartAction(TimeSpan wait)
     {
         ServiceController appDriver = new ServiceController(GetServiceName());
         if (appDriver.Status == ServiceControllerStatus.Stopped)
@@ -105,17 +109,81 @@ public sealed class UpgraderService : IHostedService
         }
     }
 
-    private void Repeat(Action<TimeSpan> action)
-    {
-        TimeSpan time = TimeSpan.FromSeconds(5);
-        int i = 5;
-        while (i >= 0)
-        {
-            action(time);
-            time *= 2;
-            i--;
-        }
-    }
+	private void StopAction(TimeSpan wait)
+	{
+		string serviceName = GetServiceName();
+
+		try
+		{
+			using ServiceController appDriver = new ServiceController(serviceName);
+
+			if (appDriver.Status == ServiceControllerStatus.Stopped || appDriver.Status == ServiceControllerStatus.StopPending)
+			{
+				return;
+			}
+
+			int processId = GetServiceProcessId(serviceName);
+			var stopwatch = Stopwatch.StartNew();
+
+			appDriver.Stop();
+			appDriver.WaitForStatus(ServiceControllerStatus.Stopped, wait);
+
+			if (processId != -1)
+			{
+				TryKillProcess(processId, wait - stopwatch.Elapsed);
+			}
+		}
+		catch (InvalidOperationException ex) when (ex.InnerException is System.ComponentModel.Win32Exception win32Ex && win32Ex.NativeErrorCode == 1062)
+		{
+            return;
+		}
+		catch (Exception ex)
+		{
+			return;
+		}
+	}
+
+	private int GetServiceProcessId(string serviceName)
+	{
+		try
+		{
+			using (var searcher = new ManagementObjectSearcher($"SELECT ProcessId FROM Win32_Service WHERE Name = '{serviceName}'"))
+			{
+				foreach (ManagementObject obj in searcher.Get())
+				{
+					return Convert.ToInt32(obj["ProcessId"]);
+				}
+			}
+		}
+		catch
+		{
+			return -1;
+		}
+		return -1;
+	}
+
+	private void TryKillProcess(int processId, TimeSpan remainingWait)
+	{
+		try
+		{
+			Process process = Process.GetProcessById(processId);
+			if (!process.HasExited)
+			{
+				if (remainingWait > TimeSpan.Zero)
+					process.WaitForExit((int)remainingWait.TotalMilliseconds);
+
+				if (!process.HasExited)
+				{
+					process.Kill();
+					process.WaitForExit();
+				}
+			}
+		}
+		catch (ArgumentException)
+		{
+            return;
+		}
+	}
 
     public Task StopAsync(CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Despite service having status stopped certain DLL files were still locked by system preventing updater from replacing them.
This modification ensures service gets fully stopped before updater starts extracting files. 



> Unhandled exception. System.IO.IOException: The process cannot access the file '<service_path>\runtimes\win\lib\net8.0\Microsoft.Data.SqlClient.dll' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode)
   at System.IO.FileStream..ctor(String path, FileStreamOptions options)
   at System.IO.Compression.ZipFileExtensions.ExtractToFile(ZipArchiveEntry source, String destinationFileName, Boolean overwrite)
   at System.IO.Compression.ZipFileExtensions.ExtractRelativeToDirectory(ZipArchiveEntry source, String destinationDirectoryName, Boolean overwrite)
   at System.IO.Compression.ZipFileExtensions.ExtractToDirectory(ZipArchive source, String destinationDirectoryName, Boolean overwriteFiles)
   at System.IO.Compression.ZipFile.ExtractToDirectory(String sourceArchiveFileName, String destinationDirectoryName, Encoding entryNameEncoding, Boolean overwriteFiles)
   at Dzidek.Net.AutoUpgrade.Upgrader.UpgraderService.UnzipAndCopyFiles(String sourcePath, String servicePath, String serviceOldVersionsPath)
   at Dzidek.Net.AutoUpgrade.Upgrader.UpgraderService.Upgrade(String newVersionPath, String binPath, String serviceOldVersionsPath)
   at Dzidek.Net.AutoUpgrade.Upgrader.UpgraderService.<>c__DisplayClass4_0.<StartAsync>b__0(Object sender, FileSystemEventArgs args)
   at System.IO.FileSystemWatcher.NotifyFileSystemEventArgs(WatcherChangeTypes changeType, ReadOnlySpan1 name)
   at System.IO.FileSystemWatcher.ParseEventBufferAndNotifyForEach(ReadOnlySpan1 buffer)
   at System.IO.FileSystemWatcher.ReadDirectoryChangesCallback(UInt32 errorCode, UInt32 numBytes, AsyncReadState state)
   at System.IO.FileSystemWatcher.<>c.<StartRaisingEvents>b__85_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* overlappedPointer)
   at System.Threading.PortableThreadPool.IOCompletionPoller.Callback.Invoke(Event e)
   at System.Threading.ThreadPoolTypedWorkItemQueue2.System.Threading.IThreadPoolWorkItem.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()